### PR TITLE
Update vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ const serverUrl = `http://${process.env.PUBLIC_HOST}:${process.env.SERVER_PORT}`
 export default defineConfig({
   plugins: [vue()],
   define: {
-    'import.meta.env.VITE_MESSAGE_SALT': JSON.stringify(process.env.VITE_MESSAGE_SALT || 'mysecretkey123')
+    'import.meta.env.VITE_MESSAGE_SALT': JSON.stringify(process.env.VITE_MESSAGE_SALT || 'default-salt-value')
   },
   server: {
     host: process.env.HOST || '0.0.0.0',


### PR DESCRIPTION
保证 client 与 server 的默认 salt 一致
这样可以防止当 .env 忘记修改的时候也能正常运行